### PR TITLE
Adds project plan skeleton document for iteration/review

### DIFF
--- a/doc/ProjectPlan.md
+++ b/doc/ProjectPlan.md
@@ -1,0 +1,71 @@
+# WPLUG Membership Portal
+
+### Project Plan
+
+
+#### Table of Contents
+
+- [Key Stakeholder](#key-stakeholder)
+- [User Stories](#user-stories)
+- [Assumptions](#assumptions)
+- [Risks](#risks)
+- [Design Document / Diagrams](#design-document-diagrams)
+- [Milestones](#milestones)
+- [Test Plan](#test-plan)
+- [User Acceptance](#user-acceptance)
+- [Documentation](#documentation)
+- [Peer Review](#peer-review)
+
+
+## Key Stakeholder
+
+> Section needs clarification on who we are serving, and who is responsible
+> for ensuring we serve these members needs.
+
+- Membership Committee Members
+- Interested Parties that want to contribute
+
+## User Stories
+
+> Section is for narrative style declaration of what we want to accomplish, including
+> a few examples that pertain to me.
+
+> As a { role } I would like to { something } because { something }
+
+- As a WPLUG member, I would like to renew my dues online because online bill-pay is easier for me than managing cash.
+- As a WPLUG member, I would like to receive renewal reminders in increments of 30, 15, and 5 day notices when my membership needs renewing, so that I never fall in areers.
+- As a Planning Event Coordinator I would like to make requests for funds for an event through this community portal and have it voted on, so that I may gauge interest in what I am proposing and have proper funding when its resolved so that I dont have to manage these things myself and have a valid paper trail.
+
+> **Note:** As this is a pre-spec document, feel free to grow the user stores as much as required - they make for great targeting for milestones when planning the project.
+
+## Assumptions
+
+> Insert any assumptions we make here, such as: technologies, universal access policies, existing policies we have to adhere to, etc.
+
+## Risks
+
+> What are the inherent risks to our project?
+
+- Membership turnover in core-developers that understand the Membership Portal, resulting in an unmaintainable platform.
+- Service Disruption due to swamp gas from saturn.
+
+## Design Document / Diagrams
+
+> If we do any ERD's and / or PDF style specs - embed them here so all we need to hand out / link to is the project spec.
+
+## Milestones
+
+> Once we have a clear User Story chart, we can further decompose those stories into actionable tasks and plan them into milestones, and assign work items to members willing to work on the project.
+
+## User Acceptance
+
+> What is the acceptance criteria per milestone? If we have a deliverable - does it have to have specific functionality? That should be oulined here with a final line-item pinning of announcement to the list with details on how this effects current workflow, and future interactions with the members.
+
+
+## Documentation
+
+> I suggest embedding markdown docs in the repository so we can do lockstep versioning of the docs with the project as it passes through milestones. Code Review + Doc Review will ensure we have everything buttoned up and tidy for any handoffs that might occur.
+
+## Peer Review
+
+> Sign off sheet of anyone thats deemed as a stakeholder that the plan is fully formed and this spec document is the defacto planning resource for the project. Once we have signatures - we are ready to start building.


### PR DESCRIPTION
This skeleton document is something I've used over several projects in the past. It adds a structured order of pre-planning thought process to bring up in the committee meetings and allows other users to really get involved in the planning / stakeholding process which will ensure we are building a tool that suits our users needs vs what we as developers think would be best.

I suggest we give this a couple of weeks, email the wplug mailing list with this spec sheet format and start to gather feedback for user stories and stakeholders - that way we can break down the work items and scope the project.

If the idea is too much for the scope of the project - just close the PR and I'll focus more on the issues vs a formal project plan.
